### PR TITLE
#15 - Implemented the design time db context factory used for migrati…

### DIFF
--- a/Source/Service/EventLogger/Migrations/DesignTimeDbContextFactory.cs
+++ b/Source/Service/EventLogger/Migrations/DesignTimeDbContextFactory.cs
@@ -1,0 +1,27 @@
+﻿using EventLogger.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace EventLogger.Migrations
+{
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<EventLoggerContext>
+    {
+        public EventLoggerContext CreateDbContext(string[] args)
+        {
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json")
+                .Build();
+            var builder = new DbContextOptionsBuilder<EventLoggerContext>();
+            var connectionString = configuration.GetConnectionString("migrationContextConnection");
+            builder.UseSqlServer(connectionString);
+            return new EventLoggerContext(builder.Options);
+        }
+    }
+}

--- a/Source/Service/EventLogger/Startup.cs
+++ b/Source/Service/EventLogger/Startup.cs
@@ -31,7 +31,10 @@ namespace EventLogger
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
             
-            services.AddDbContext<EventLoggerContext>(options => options.UseSqlServer(Configuration["ConnectionString"]));
+
+            var connectionString = Configuration.GetConnectionString("runtimeContextConnection");
+
+            services.AddDbContext<EventLoggerContext>(options => options.UseSqlServer(connectionString));
 
             services.AddTransient<IEventLoggerRepository, EventLoggerRepository>();
         }

--- a/Source/Service/EventLogger/appsettings.json
+++ b/Source/Service/EventLogger/appsettings.json
@@ -5,5 +5,8 @@
     }
   },
   "AllowedHosts": "*",
-  "ConnectionString": "Server=sql.data,1433;Database=RockId.EventLogger;User Id=sa;Password=Pass@word"
+  "ConnectionStrings": {
+    "migrationContextConnection": "Server=localhost,5433;Database=RockId.EventLogger;User Id=sa;Password=Pass@word",
+    "runtimeContextConnection": "Server=sql.data,1433;Database=RockId.EventLogger;User Id=sa;Password=Pass@word"
+  }
 }


### PR DESCRIPTION
…ons.  This allows the connection string for migrations (docker host network-based) to be different than the connection string at runtime (container network-based).